### PR TITLE
Fix strict TypeScript test mocks causing Render build failures

### DIFF
--- a/src/backup/restore-service.test.ts
+++ b/src/backup/restore-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { initialFinanceState } from '../domain/default-data'
 import type { FinanceState } from '../domain/models'
 import { buildBackupPayload } from './backup-service'
@@ -185,11 +185,12 @@ describe('prepareBackupRestore', () => {
   })
 
   it('returns a safe error when reading backup file fails', async () => {
-    const result = await prepareBackupRestoreFile({
-      text: async () => {
-        throw new Error('unreadable file')
-      },
-    } as File)
+    const unreadableFile = new File(['{}'], 'backup.json', {
+      type: 'application/json',
+    })
+    vi.spyOn(unreadableFile, 'text').mockRejectedValue(new Error('unreadable file'))
+
+    const result = await prepareBackupRestoreFile(unreadableFile)
 
     expect(result).toEqual({
       ok: false,

--- a/src/features/settings/settings-screen.test.tsx
+++ b/src/features/settings/settings-screen.test.tsx
@@ -5,12 +5,14 @@ import { SettingsScreen } from './settings-screen'
 import { createFinanceContextValue, renderWithFinance } from '../../test/finance-test-utils'
 import { initialFinanceState } from '../../domain/default-data'
 import type { FinanceState } from '../../domain/models'
+import type { PreparedBackupRestoreResult } from '../../backup/backup-models'
+import type { FinanceContextValue } from '../../state/finance-store'
 
 const restoreState = vi.hoisted(() => ({
   result: {
     ok: false as const,
     message: 'This backup file is not valid.',
-  },
+  } as PreparedBackupRestoreResult,
 }))
 
 vi.mock('../../backup/restore-service', () => ({
@@ -33,7 +35,10 @@ function createState(overrides: Partial<FinanceState> = {}): FinanceState {
   }
 }
 
-function renderScreen(state: FinanceState, overrides = {}) {
+function renderScreen(
+  state: FinanceState,
+  overrides: Partial<FinanceContextValue> = {},
+) {
   const replaceState = vi.fn(async () => undefined)
   const onShowToast = vi.fn()
   const onOpenRecurringEditor = vi.fn()

--- a/src/state/finance-context.test.tsx
+++ b/src/state/finance-context.test.tsx
@@ -52,6 +52,7 @@ function installMatchMedia(initialMatches: boolean) {
     removeListener: vi.fn((listener: (event: MediaQueryListEvent) => void) => {
       listeners.delete(listener)
     }),
+    dispatchEvent: vi.fn(() => true),
     dispatch(nextMatches: boolean) {
       mediaQueryList.matches = nextMatches
       const event = { matches: nextMatches } as MediaQueryListEvent


### PR DESCRIPTION
## Summary
This PR fixes TypeScript build errors that were failing `npm run build` on Render (`tsc -b && vite build`), all in test files with strict typing issues.

## What changed
- Updated backup restore file-read failure test to use a real `File` and mock `text()` rejection safely.
  - restore-service.test.ts
- Typed restore mock state as `PreparedBackupRestoreResult` to avoid incorrect literal narrowing of `ok`.
- Typed `renderScreen` overrides as `Partial<FinanceContextValue>` to remove implicit `any`.
  - settings-screen.test.tsx
- Completed `MediaQueryList` test double by adding `dispatchEvent`.
  - finance-context.test.tsx

## Why
Render build failed due to strict TS errors:
- unsafe structural casts to `File` / `MediaQueryList`
- implicit `any` in test callback parameter
- discriminated union mock narrowed to `{ ok: false }`, then assigned `{ ok: true }`

## Validation
- Ran `npm run build` locally
- Result: build passes (`tsc -b` + `vite build` + PWA/service worker build)

## Impact
- No production runtime behavior changes
- Test typing/mocks are now strict-TS compatible and CI/deploy-safe