### PR TITLE
docs: add high-signal Copilot review instructions for state and persistence risks

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,24 @@
+# Copilot PR Review Instructions
+
+Focus review comments on regression prevention and data correctness.
+Comment only when there is a concrete bug risk, missing safeguard, missing test, ambiguous behavior, or meaningful maintainability risk.
+
+## Priorities
+
+- Protect state invariants and cross-entity consistency (categories, transactions, recurring templates, budgets, settings).
+- Prioritize migration/restore and persistence safety over implementation style preferences.
+- Verify financial totals and derived values remain correct across Home, Insights, and Budgets.
+- Prefer targeted test requests for risky changes over broad refactor suggestions.
+
+## Comment Quality
+
+- Explain what can break, who it impacts, and what evidence would make it safe.
+- Keep comments specific, calm, and action-oriented.
+- Ask for focused tests when touching high-risk logic paths.
+
+## Ignore Noise
+
+- Do not leave style-only, formatting-only, or wording-only comments.
+- Ignore harmless local naming differences and CSS/class ordering unless behavior/accessibility breaks.
+- Do not suggest broad refactors when the PR scope is intentionally narrow.
+- Avoid generic advice (for example, "follow best practices" or "add comments").

--- a/.github/instructions/domain-persistence-review.instructions.md
+++ b/.github/instructions/domain-persistence-review.instructions.md
@@ -1,0 +1,35 @@
+---
+description: "Use when reviewing domain, backup/restore, or persistence changes. Focus on migration safety, date logic, financial calculations, and storage fallback durability."
+applyTo: "src/domain/**,src/backup/**,src/persistence/**,src/pwa/**,src/sw.ts,src/features/insights/insights-charts.tsx,src/features/shell/use-editor-orchestration.ts"
+---
+# Domain and Persistence Review Focus
+
+Optimize for data integrity and recovery safety.
+
+## Must Check
+
+- Persisted and backup payload parsing rejects invalid shapes without corrupting valid user data.
+- Legacy migration behavior remains compatible and preserves expected defaults.
+- Category deletion plans correctly propagate to transactions, recurring templates, and budgets.
+- Recurring processing enforces ordered processible dates and correct `nextDueDate` advancement.
+- Selector or budgeting math changes do not alter financial totals unexpectedly across screens.
+- Persistence writes remain durable with safe IndexedDB/localStorage fallback behavior.
+
+## Test Expectations
+
+Request targeted tests for changes to:
+
+- `src/domain/validation.ts`
+- `src/domain/recurring.ts`
+- `src/domain/category-service.ts`
+- `src/domain/selectors.ts`
+- `src/backup/restore-service.ts`
+- `src/persistence/finance-storage.ts`
+
+Strongly prefer adding focused tests when touching currently under-tested infra paths:
+
+- `src/persistence/indexeddb.ts`
+- `src/pwa/register-service-worker.ts`
+- `src/sw.ts`
+- `src/features/insights/insights-charts.tsx`
+- `src/features/shell/use-editor-orchestration.ts`

--- a/.github/instructions/state-review.instructions.md
+++ b/.github/instructions/state-review.instructions.md
@@ -1,0 +1,27 @@
+---
+description: "Use when reviewing changes in src/state, reducer actions, finance context orchestration, or high-impact UI flows that dispatch state mutations. Focus on invariants, cross-entity updates, and regression tests."
+applyTo: "src/state/**,src/App.tsx,src/features/settings/settings-screen.tsx,src/features/transactions/transaction-editor-sheet.tsx,src/features/recurring/recurring-due-section.tsx"
+---
+# State Review Focus
+
+Prioritize correctness of reducer/context behavior over code style.
+
+## Must Check
+
+- Every action preserves invariants for category compatibility, budget validity, recurring validity, and settings shape.
+- Reducer changes do not silently bypass validation done in domain/context layers.
+- `changesSinceBackup` semantics stay correct for meaningful mutations.
+- Actions that touch multiple entities keep transactions, recurring templates, and budgets in sync.
+- Date-sensitive state transitions (recurring due processing, skips, next due updates) remain deterministic and idempotent.
+
+## Test Expectations
+
+Request targeted tests for any changes to:
+
+- `src/state/finance-reducer.ts`
+- `src/state/finance-context.tsx`
+- `src/state/finance-reducer-types.ts`
+- `src/state/reducer-cases/**`
+- `src/state/reducer-utils/**`
+
+Prefer concrete missing-case tests over broad "more tests" comments.


### PR DESCRIPTION
## Summary
Adds repository-level and path-specific GitHub Copilot review instructions to improve PR review signal quality.  
This guides Copilot to focus on regression prevention, data integrity, and missing safeguards/tests in the riskiest areas (state core, domain validation/migration, backup/restore, and persistence), while reducing style-only review noise.

## Related issue
Closes #

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / tech debt
- [x] Documentation
- [ ] Test-only
- [x] Chore

## What was changed
- Added a concise repo-wide review baseline in copilot-instructions.md focused on correctness, regression risk, and actionable comments.
- Added path-specific rules:
  - state-review.instructions.md
  - domain-persistence-review.instructions.md
- Scoped strict checks to high-risk files via `applyTo` patterns (state flows, domain/persistence/backup, and selected orchestration/chart files).
- Enforced anti-noise guidance so Copilot avoids low-value style/formatting comments and broad refactor suggestions outside PR scope.

## Testing
List what you ran and what was verified.

- [x] Unit tests
- [x] E2E tests
- [x] Manual verification

Details:
- Verified instruction files are in supported locations:
  - copilot-instructions.md
  - `.github/instructions/*.instructions.md`
- Verified `.instructions.md` frontmatter uses valid `description` and comma-separated `applyTo` strings.
- Reviewed final content for brevity/high-signal focus (under code review instruction size constraints).
- Confirmed guidance aligns with repository risk profile: state invariants, migration/restore safety, recurring correctness, totals integrity, persistence fallback durability.

## Checklist
- [x] I completed a self-review of this PR.
- [ ] I added or updated tests where needed.
- [x] I updated documentation when behavior or developer workflow changed.
- [x] This PR does not include unrelated changes.