### PR TITLE
docs: integrate architecture/data-model/testing/contributing docs and align README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,16 @@ It focuses on **clarity, speed, and usability**, without unnecessary complexity.
 
 ### Settings
 
-- Theme toggle (light and dark)
+- Theme selection (light, dark, or auto)
 - Currency selection
 - Category management
-- Sync status and manual sync trigger
 - Optional install prompt (PWA)
 
 ## Offline-First
 
 - IndexedDB-based persistence
 - Works fully offline
-- Offline changes are retained until synced
+- Offline changes are retained locally on the device
 
 ## Additional Options
 
@@ -114,6 +113,13 @@ npm run build
 npm run preview
 ```
 
+## Documentation
+
+- [Architecture](./docs/architecture.md)
+- [Data model](./docs/data-model.md)
+- [Testing guide](./docs/testing.md)
+- [Contributing guide](./docs/contributing.md)
+
 ## Project Structure
 
 ```text
@@ -124,7 +130,6 @@ src/
   persistence/   IndexedDB and local state persistence
   pwa/           Service worker registration and install prompt handling
   state/         Finance context, reducer, and store interfaces
-  sync/          Queue sync client and related sync flow
   utils/         Shared utilities (date, id, download, etc.)
 ```
 
@@ -136,14 +141,14 @@ Tally follows a React + TypeScript architecture with clear boundaries:
 - State Layer (`src/state/`): central state with context + reducer updates
 - Domain Layer (`src/domain/`): pure, reusable business logic and selectors
 - Persistence Layer (`src/persistence/`): local durable storage for offline-first use
-- Sync Layer (`src/sync/`): optional queue-based synchronization to a configured endpoint
+- Backup Layer (`src/backup/`): backup export, restore validation, and reminders
+- PWA Layer (`src/pwa/`, `src/sw.ts`): install prompt handling and offline shell caching
 
 This split keeps business logic testable and the UI focused on interaction.
 
 ## Limitations
 
 - Single-user local app; no built-in accounts or multi-device identity
-- Sync requires a compatible endpoint implementation; no hosted backend is included
 - Clearing browser/app storage can remove local data
 - Backup files are plain JSON and should be handled securely
 - No built-in advanced accounting or tax/reporting workflows beyond current insights and CSV export

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,271 @@
+# Tally Architecture
+
+## High-Level Overview
+
+Tally is a local-first React + TypeScript finance app. The browser is the runtime, local storage is the system of record, and all main features operate without a backend.
+
+Related docs:
+
+- [Data model](./data-model.md)
+- [Testing guide](./testing.md)
+- [Contributing guide](./contributing.md)
+
+At startup:
+
+1. The app registers a service worker for offline caching.
+2. The app mounts a single finance provider.
+3. The provider hydrates state from persisted storage.
+4. After hydration, state changes are persisted back to storage.
+
+Primary references:
+
+- [src/main.tsx](../src/main.tsx)
+- [src/App.tsx](../src/App.tsx)
+- [src/state/finance-context.tsx](../src/state/finance-context.tsx)
+- [src/persistence/finance-storage.ts](../src/persistence/finance-storage.ts)
+
+## Module Boundaries
+
+### UI and Screen Composition
+
+Feature UI lives in [src/features](../src/features). The app shell selects one active tab and resolves the active screen.
+
+- Screen routing and shell orchestration: [src/features/shell/app-screen-resolver.tsx](../src/features/shell/app-screen-resolver.tsx)
+- Home: [src/features/home/home-screen.tsx](../src/features/home/home-screen.tsx)
+- Transactions: [src/features/transactions/transactions-screen.tsx](../src/features/transactions/transactions-screen.tsx)
+- Insights: [src/features/insights/insights-screen.tsx](../src/features/insights/insights-screen.tsx)
+- Budgets: [src/features/budgets/budgets-screen.tsx](../src/features/budgets/budgets-screen.tsx)
+- Settings: [src/features/settings/settings-screen.tsx](../src/features/settings/settings-screen.tsx)
+
+UI components should stay focused on rendering, user interactions, and invoking context actions.
+
+### State and Action Orchestration
+
+State is centralized behind a React context + reducer pair:
+
+- Provider and action methods: [src/state/finance-context.tsx](../src/state/finance-context.tsx)
+- Reducer root: [src/state/finance-reducer.ts](../src/state/finance-reducer.ts)
+- Action types: [src/state/finance-reducer-types.ts](../src/state/finance-reducer-types.ts)
+- Consumer hook: [src/state/use-finance.ts](../src/state/use-finance.ts)
+
+The provider performs input shaping and guards before dispatch. The reducer enforces compatibility and no-op behavior for invalid transitions.
+
+### Domain Logic
+
+Pure business rules and derived computations are in [src/domain](../src/domain):
+
+- State model types: [src/domain/models.ts](../src/domain/models.ts)
+- Default bootstrap state: [src/domain/default-data.ts](../src/domain/default-data.ts)
+- Validation and migration parser: [src/domain/validation.ts](../src/domain/validation.ts)
+- Category deletion planning: [src/domain/category-service.ts](../src/domain/category-service.ts)
+- Recurring scheduling and due detection: [src/domain/recurring.ts](../src/domain/recurring.ts)
+- Summaries and analytics selectors: [src/domain/selectors.ts](../src/domain/selectors.ts)
+- Budget category normalization and spend math: [src/domain/budget-service.ts](../src/domain/budget-service.ts)
+
+### Persistence and Offline Runtime
+
+Persistence and offline shell behavior are separated from business rules:
+
+- Persistence orchestration with fallback strategy: [src/persistence/finance-storage.ts](../src/persistence/finance-storage.ts)
+- IndexedDB adapter: [src/persistence/indexeddb.ts](../src/persistence/indexeddb.ts)
+- Service worker registration hook: [src/pwa/register-service-worker.ts](../src/pwa/register-service-worker.ts)
+- Service worker runtime caching rules: [src/sw.ts](../src/sw.ts)
+
+### Backup and Restore
+
+Backup and restore are versioned and validated:
+
+- Backup schema and result types: [src/backup/backup-models.ts](../src/backup/backup-models.ts)
+- Backup export and download: [src/backup/backup-service.ts](../src/backup/backup-service.ts)
+- Restore preparation and payload validation: [src/backup/restore-service.ts](../src/backup/restore-service.ts)
+- Restore UX path: [src/features/settings/settings-screen.tsx](../src/features/settings/settings-screen.tsx)
+
+## State Management Approach
+
+Tally uses a single FinanceState object that contains categories, transactions, budgets, recurring templates, and settings.
+
+Load/save lifecycle:
+
+1. Provider initializes reducer with default state.
+2. Provider loads persisted state and dispatches hydrate when available.
+3. Provider sets isLoaded once hydration attempt completes.
+4. Persist effect writes each post-load state update.
+
+References:
+
+- [src/state/finance-context.tsx](../src/state/finance-context.tsx)
+- [src/domain/models.ts](../src/domain/models.ts)
+- [src/persistence/finance-storage.ts](../src/persistence/finance-storage.ts)
+
+Change tracking behavior:
+
+- Reducer helper increments settings.changesSinceBackup for meaningful data mutations.
+- Settings-only updates do not use that helper.
+- Hydrate and replace-state do not increment change counter.
+
+References:
+
+- [src/state/reducer-utils/change-tracking.ts](../src/state/reducer-utils/change-tracking.ts)
+- [src/state/reducer-cases/meta-settings.ts](../src/state/reducer-cases/meta-settings.ts)
+
+## Domain vs UI Responsibilities
+
+Domain layer responsibilities:
+
+- Parse and normalize persisted state.
+- Keep category and transaction type compatibility valid.
+- Plan multi-entity category deletion impact.
+- Compute recurring due dates and processible sequences.
+- Produce totals and chart inputs for screens.
+
+UI layer responsibilities:
+
+- Collect user input and trigger context actions.
+- Display derived values and warnings/messages.
+- Present confirm flows for destructive actions and restore.
+
+Representative boundary examples:
+
+- Category deletion planning in domain, execution via state reducer:
+  - [src/domain/category-service.ts](../src/domain/category-service.ts)
+  - [src/state/finance-reducer.ts](../src/state/finance-reducer.ts)
+- Recurring due computation in domain, user confirmation in UI:
+  - [src/domain/recurring.ts](../src/domain/recurring.ts)
+  - [src/features/recurring/recurring-due-section.tsx](../src/features/recurring/recurring-due-section.tsx)
+
+## Persistence and Storage Flow
+
+Read flow:
+
+1. Attempt IndexedDB read.
+2. Parse with parsePersistedFinanceState.
+3. If IndexedDB path fails or parses as null, fall back to localStorage.
+4. Return null if both paths fail.
+
+Write flow:
+
+1. Attempt IndexedDB write.
+2. Attempt localStorage write.
+3. Succeed if at least one write path succeeded.
+4. Throw only when both writes fail.
+
+This design prioritizes durability through dual-path writes and tolerant reads.
+
+References:
+
+- [src/persistence/finance-storage.ts](../src/persistence/finance-storage.ts)
+- [src/persistence/indexeddb.ts](../src/persistence/indexeddb.ts)
+- [src/domain/validation.ts](../src/domain/validation.ts)
+
+## Backup and Restore Flow
+
+Backup export:
+
+1. Build a versioned payload from current state.
+2. Reset backup-related preference fields in exported preferences.
+3. Serialize and trigger JSON download.
+
+Restore import:
+
+1. Parse JSON file.
+2. Validate version/app marker and structural fields.
+3. Re-parse through parsePersistedFinanceState to normalize/migrate.
+4. Build nextState and require user confirmation.
+5. On confirm, write nextState through replaceState (save first, then dispatch).
+
+References:
+
+- [src/backup/backup-service.ts](../src/backup/backup-service.ts)
+- [src/backup/restore-service.ts](../src/backup/restore-service.ts)
+- [src/features/settings/settings-screen.tsx](../src/features/settings/settings-screen.tsx)
+- [src/state/finance-context.tsx](../src/state/finance-context.tsx)
+
+## Recurring Transaction Handling
+
+Recurring templates are first-class state entities, not inferred from transaction history.
+
+Processing model:
+
+1. Domain computes due occurrences up to today for each active template.
+2. UI presents due groups on Home for explicit user action.
+3. User can add occurrences, skip occurrences, edit the template, or stop recurrence.
+4. Reducer updates transactions and nextDueDate based on processed count.
+
+Safety behavior:
+
+- Requested recurring occurrence dates must match an ordered prefix of currently due dates.
+- Invalid or out-of-order date sets are rejected.
+
+References:
+
+- [src/domain/recurring.ts](../src/domain/recurring.ts)
+- [src/features/recurring/recurring-due-section.tsx](../src/features/recurring/recurring-due-section.tsx)
+- [src/state/finance-context.tsx](../src/state/finance-context.tsx)
+- [src/state/finance-reducer.ts](../src/state/finance-reducer.ts)
+
+## Key Invariants and Risk-Sensitive Areas
+
+Category invariants:
+
+- Uncategorized system category must exist.
+- System categories cannot be deleted.
+- Category kind must remain compatible with linked transactions and recurring templates.
+- Category deletion must propagate safely to transactions, recurring templates, and budgets.
+
+References:
+
+- [src/domain/categories.ts](../src/domain/categories.ts)
+- [src/domain/validation.ts](../src/domain/validation.ts)
+- [src/domain/category-service.ts](../src/domain/category-service.ts)
+- [src/state/finance-reducer.ts](../src/state/finance-reducer.ts)
+
+Budget invariants:
+
+- Budget limit must be finite and greater than zero.
+- Budget categories are normalized and restricted to valid expense categories.
+- Duplicate budget names in the same month are blocked in provider-level checks.
+
+References:
+
+- [src/domain/budget-service.ts](../src/domain/budget-service.ts)
+- [src/state/reducer-cases/budgets.ts](../src/state/reducer-cases/budgets.ts)
+- [src/state/finance-context.tsx](../src/state/finance-context.tsx)
+
+Persistence and migration invariants:
+
+- Persisted payloads are accepted only through parsePersistedFinanceState.
+- Legacy shapes are migrated where supported.
+- Invalid category references in transactions and recurring templates are normalized to Uncategorized.
+
+References:
+
+- [src/domain/validation.ts](../src/domain/validation.ts)
+- [src/persistence/finance-storage.ts](../src/persistence/finance-storage.ts)
+
+Backup/restore invariants:
+
+- Unsupported backup schema versions are rejected.
+- Restore path validates and normalizes data before applying.
+- Restore writes to persistence before reducer replacement to avoid in-memory-only restore state.
+
+References:
+
+- [src/backup/restore-service.ts](../src/backup/restore-service.ts)
+- [src/state/finance-context.tsx](../src/state/finance-context.tsx)
+
+## Where To Start (Contributors)
+
+Suggested reading order for architecture onboarding:
+
+1. [src/domain/models.ts](../src/domain/models.ts) for core entities.
+2. [src/state/finance-context.tsx](../src/state/finance-context.tsx) for app-level action orchestration.
+3. [src/state/finance-reducer.ts](../src/state/finance-reducer.ts) and reducer cases for mutation rules.
+4. [src/domain/validation.ts](../src/domain/validation.ts) for migration and parse guarantees.
+5. [src/features/home/home-screen.tsx](../src/features/home/home-screen.tsx) and [src/features/settings/settings-screen.tsx](../src/features/settings/settings-screen.tsx) for high-impact UX flows.
+
+Suggested first test files to understand behavior constraints:
+
+- [src/state/finance-reducer.test.ts](../src/state/finance-reducer.test.ts)
+- [src/domain/category-service.test.ts](../src/domain/category-service.test.ts)
+- [src/domain/recurring.test.ts](../src/domain/recurring.test.ts)
+- [src/backup/restore-service.test.ts](../src/backup/restore-service.test.ts)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,110 @@
+# Contributing to Tally
+
+Thanks for contributing.
+
+This guide covers practical contributor workflow for this repository.
+
+For codebase context, see [docs/architecture.md](./architecture.md), [docs/data-model.md](./data-model.md), and [docs/testing.md](./testing.md).
+
+## Local setup
+
+1. Fork and clone the repository.
+2. Install dependencies:
+
+```bash
+npm install
+```
+
+3. Start the dev server:
+
+```bash
+npm run dev
+```
+
+4. Open the app in the URL shown by Vite.
+
+## Common scripts
+
+Defined in [package.json](../package.json):
+
+- npm run dev: Start local development server.
+- npm run build: Type-check and build production assets.
+- npm run lint: Run ESLint.
+- npm run test: Run unit and component tests (Vitest).
+- npm run test:watch: Run Vitest in watch mode.
+- npm run test:coverage: Run Vitest with coverage.
+- npm run test:e2e: Run Playwright e2e tests (non-visual).
+- npm run test:visual: Run Playwright visual regression tests.
+- npm run test:visual:update: Update visual snapshots intentionally.
+
+## Issues
+
+Use the issue templates in [/.github/ISSUE_TEMPLATE](../.github/ISSUE_TEMPLATE):
+
+- Bug report
+- Feature request
+- Refactor / tech debt
+
+Issue templates request clear goals, scope, tasks, and acceptance criteria. Blank issues are disabled in [/.github/ISSUE_TEMPLATE/config.yml](../.github/ISSUE_TEMPLATE/config.yml).
+
+## Pull requests
+
+Use [/.github/pull_request_template.md](../.github/pull_request_template.md) and fill all relevant sections:
+
+- Summary and related issue
+- Type of change
+- What changed
+- Testing performed
+- Checklist items
+
+Keep PRs scoped. Avoid bundling unrelated refactors with behavior changes.
+
+## Testing expectations
+
+CI in [/.github/workflows/ci.yml](../.github/workflows/ci.yml) runs:
+
+1. Lint
+2. Unit/component tests
+3. Playwright e2e
+4. Playwright visual regression
+
+Before opening or updating a PR, run the tests that match your changes.
+
+When targeted tests are expected:
+
+- State invariants or reducer logic changes.
+- Data model, parsing, migration, or restore changes.
+- Recurring scheduling/processing changes.
+- Persistence behavior changes.
+- Financial totals/selector changes used by Home, Insights, or Budgets.
+- Cross-screen UI flow changes.
+
+See [docs/testing.md](./testing.md) for module-level testing guidance.
+
+## Review focus for this repo
+
+PR review guidance in [/.github/copilot-instructions.md](../.github/copilot-instructions.md) prioritizes:
+
+- Regression prevention and data correctness.
+- State invariants and cross-entity consistency.
+- Migration/restore and persistence safety.
+- Financial totals correctness.
+- Targeted tests for high-risk changes.
+
+## Documentation updates
+
+Update docs in the same PR when behavior or contributor workflow changes.
+
+Typical triggers:
+
+- New or changed scripts, CI checks, or test workflow.
+- Changes to state invariants or model relationships.
+- Changes to backup/restore or persistence behavior.
+- New contributor-facing conventions.
+
+## Scope and quality expectations
+
+- Keep changes focused and easy to review.
+- Preserve existing behavior unless the issue or PR scope explicitly changes it.
+- Prefer small, targeted tests over broad rewrites.
+- Call out uncertainties directly in PR notes when behavior is ambiguous.

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -1,0 +1,206 @@
+# Tally Data Model
+
+This document describes the persisted application model and the guardrails that keep it consistent.
+
+For architecture context, see [docs/architecture.md](./architecture.md).
+
+## Canonical State Shape
+
+The canonical model is `FinanceState` in [src/domain/models.ts](../src/domain/models.ts):
+
+- `categories: Category[]`
+- `transactions: Transaction[]`
+- `budgets: Budget[]`
+- `recurringTemplates: RecurringTemplate[]`
+- `settings: AppSettings`
+
+All persistence and backup restore paths are normalized through `parsePersistedFinanceState` in [src/domain/validation.ts](../src/domain/validation.ts).
+
+## Core Entities
+
+### Category
+
+Defined in [src/domain/models.ts](../src/domain/models.ts) as:
+
+- Identity and timestamps: `id`, `createdAt`, `updatedAt`
+- Display/model fields: `name`, `color`, `kind`, `system`
+
+Important semantics:
+
+- `kind` is one of `income`, `expense`, `both`.
+- `system` is either `uncategorized` or `null`.
+- The uncategorized category is reserved and treated as non-deletable.
+
+References:
+
+- [src/domain/categories.ts](../src/domain/categories.ts)
+- [src/domain/category-service.ts](../src/domain/category-service.ts)
+- [src/state/finance-reducer.ts](../src/state/finance-reducer.ts)
+
+### Transaction
+
+Defined in [src/domain/models.ts](../src/domain/models.ts) as:
+
+- Identity and timestamps: `id`, `createdAt`, `updatedAt`
+- Financial fields: `type`, `amount`, `categoryId`, `occurredAt`
+- Metadata: `note`
+- Recurring linkage: `recurringTemplateId`, `recurringOccurrenceDate`
+
+Important semantics:
+
+- `amount` is expected to be positive in stored state.
+- `type` drives category compatibility checks.
+- Recurring linkage fields are nullable and can be absent in legacy data, then migrated to `null`.
+
+References:
+
+- [src/state/reducer-cases/transactions.ts](../src/state/reducer-cases/transactions.ts)
+- [src/domain/validation.ts](../src/domain/validation.ts)
+
+### Budget
+
+Defined in [src/domain/models.ts](../src/domain/models.ts) as:
+
+- Identity and timestamps: `id`, `createdAt`, `updatedAt`
+- Budget fields: `name`, `categoryIds`, `monthKey`, `limit`
+
+Important semantics:
+
+- Budgets are multi-category (`categoryIds[]`), not single-category.
+- Categories are normalized to valid expense categories.
+- `limit` must be finite and greater than zero.
+
+References:
+
+- [src/domain/budget-service.ts](../src/domain/budget-service.ts)
+- [src/state/reducer-cases/budgets.ts](../src/state/reducer-cases/budgets.ts)
+- [src/domain/validation.ts](../src/domain/validation.ts)
+
+### RecurringTemplate
+
+Defined in [src/domain/models.ts](../src/domain/models.ts) as:
+
+- Identity and timestamps: `id`, `createdAt`, `updatedAt`
+- Financial fields: `type`, `amount`, `categoryId`, `note`
+- Schedule fields: `frequency`, `intervalDays`, `startDate`, `nextDueDate`
+- Lifecycle field: `active`
+
+Important semantics:
+
+- `frequency` is `monthly` or `custom`.
+- `intervalDays` is `null` for `monthly` and numeric for `custom`.
+- `nextDueDate` advances only through recurring processing actions.
+
+References:
+
+- [src/domain/recurring.ts](../src/domain/recurring.ts)
+- [src/state/finance-context.tsx](../src/state/finance-context.tsx)
+- [src/state/finance-reducer.ts](../src/state/finance-reducer.ts)
+
+### AppSettings and BackupPreferences
+
+Defined in [src/domain/models.ts](../src/domain/models.ts).
+
+`AppSettings` extends backup metadata with UI settings:
+
+- UI settings: `theme`, `currency`
+- Backup metadata: `hasSeenPrivacyModal`, `backupRemindersEnabled`, `lastBackupAt`, `changesSinceBackup`, `lastReminderAt`
+
+Important semantics:
+
+- `currency` is validated as 3-letter string during parsing.
+- `changesSinceBackup` increments on meaningful reducer mutations.
+
+References:
+
+- [src/state/reducer-utils/change-tracking.ts](../src/state/reducer-utils/change-tracking.ts)
+- [src/state/reducer-cases/meta-settings.ts](../src/state/reducer-cases/meta-settings.ts)
+
+## Relationships Between Entities
+
+### Category References
+
+- `Transaction.categoryId -> Category.id`
+- `RecurringTemplate.categoryId -> Category.id`
+- `Budget.categoryIds[] -> Category.id[]`
+
+Compatibility rules:
+
+- Transaction and recurring template type must be compatible with category `kind`.
+- Budget category lists are normalized and filtered to valid expense categories.
+
+References:
+
+- [src/state/reducer-utils/category-compat.ts](../src/state/reducer-utils/category-compat.ts)
+- [src/domain/budget-service.ts](../src/domain/budget-service.ts)
+- [src/domain/validation.ts](../src/domain/validation.ts)
+
+### Recurring to Transactions Link
+
+- `Transaction.recurringTemplateId` may reference a template.
+- `Transaction.recurringOccurrenceDate` records which due date was applied.
+- Recurring processing creates transactions and advances template `nextDueDate`.
+
+References:
+
+- [src/domain/recurring.ts](../src/domain/recurring.ts)
+- [src/state/finance-context.tsx](../src/state/finance-context.tsx)
+
+## Constraints and Invariants
+
+### Parse-Time and Migration Invariants
+
+Enforced in [src/domain/validation.ts](../src/domain/validation.ts):
+
+- Non-object or structurally invalid persisted payloads return `null`.
+- Uncategorized category is ensured in parsed output.
+- Legacy transaction recurring fields are defaulted to `null`.
+- Legacy budget shape (`categoryId`) is migrated to `categoryIds[]`.
+- Invalid transaction and recurring category references are rewritten to Uncategorized.
+- Invalid budget entries are dropped rather than retained in partial-invalid form.
+
+### Reducer/Action Invariants
+
+Enforced in [src/state/finance-reducer.ts](../src/state/finance-reducer.ts) and reducer cases:
+
+- Invalid transaction amount/category compatibility produces no-op state transitions.
+- System categories cannot be deleted or updated as normal categories.
+- Category updates are blocked when they would break linked transactions, recurring templates, or budgets.
+- Category deletion executes a precomputed plan that updates transactions, recurring templates, and budgets in one transition.
+- Recurring occurrence additions/skips require a valid template and valid occurrence set.
+
+### Backup/Restore Invariants
+
+Enforced in [src/backup/restore-service.ts](../src/backup/restore-service.ts):
+
+- Only supported schema versions are accepted.
+- Parsed backup data is normalized via `parsePersistedFinanceState` before restore.
+- Schema v1 backups are accepted; recurring templates default to empty during normalization.
+- Restored settings force `changesSinceBackup = 0` and clear `lastReminderAt`.
+
+## Migration and Persistence-Sensitive Fields
+
+The following areas are high-risk when changing the model:
+
+- `Category.system` and uncategorized handling.
+- `Transaction.categoryId` and `RecurringTemplate.categoryId` normalization behavior.
+- `Transaction.recurringTemplateId` and `Transaction.recurringOccurrenceDate` migration defaults.
+- `Budget.categoryIds` and legacy budget migration behavior.
+- `AppSettings` backup metadata fields, especially `changesSinceBackup` and `lastBackupAt`.
+- Storage key/version assumptions in [src/persistence/finance-storage.ts](../src/persistence/finance-storage.ts).
+- Backup schema and payload contract in [src/backup/backup-models.ts](../src/backup/backup-models.ts).
+
+## Practical Change Checklist
+
+When changing data model fields or relationships:
+
+1. Update model types in [src/domain/models.ts](../src/domain/models.ts).
+2. Update parse/migration rules in [src/domain/validation.ts](../src/domain/validation.ts).
+3. Update reducer compatibility and invariants in [src/state/finance-reducer.ts](../src/state/finance-reducer.ts) and reducer cases.
+4. Update backup schema/types/services in [src/backup/backup-models.ts](../src/backup/backup-models.ts), [src/backup/backup-service.ts](../src/backup/backup-service.ts), and [src/backup/restore-service.ts](../src/backup/restore-service.ts).
+5. Add or update focused tests in:
+   - [src/domain/validation.test.ts](../src/domain/validation.test.ts)
+   - [src/domain/category-service.test.ts](../src/domain/category-service.test.ts)
+   - [src/domain/recurring.test.ts](../src/domain/recurring.test.ts)
+   - [src/backup/restore-service.test.ts](../src/backup/restore-service.test.ts)
+   - [src/state/finance-reducer.test.ts](../src/state/finance-reducer.test.ts)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,138 @@
+# Testing Guide
+
+This document explains the current automated test setup and how to use it when making changes.
+
+For architecture and module boundaries, see [docs/architecture.md](./architecture.md).
+For contributor workflow expectations, see [docs/contributing.md](./contributing.md).
+
+## Test Stack
+
+### Unit and Integration (Vitest + RTL)
+
+- Runner and config: [vite.config.ts](../vite.config.ts)
+- Environment: `jsdom`
+- Setup file: [src/test/setup-tests.ts](../src/test/setup-tests.ts)
+- Includes: `src/**/*.{test,spec}.{ts,tsx}`
+- Excludes: `e2e/**`
+
+`setup-tests.ts` also installs compatibility shims used by app code (for example `matchMedia`, animation frame APIs, and pointer capture APIs).
+
+### End-to-End and Visual (Playwright)
+
+- Runner config: [playwright.config.ts](../playwright.config.ts)
+- Non-visual e2e suite: [e2e/app.e2e.spec.ts](../e2e/app.e2e.spec.ts)
+- Visual snapshot suite: [e2e/visual.spec.ts](../e2e/visual.spec.ts)
+- Visual baselines: [e2e/visual.spec.ts-snapshots](../e2e/visual.spec.ts-snapshots)
+
+Playwright uses a dev server started from `npm run dev` and targets Chromium by default.
+
+## Running Tests Locally
+
+From repository root:
+
+```bash
+npm run test
+npm run test:watch
+npm run test:coverage
+npm run test:e2e
+npm run test:visual
+```
+
+To update visual snapshots intentionally:
+
+```bash
+npm run test:visual:update
+```
+
+Scripts are defined in [package.json](../package.json).
+
+## CI Workflow Alignment
+
+CI is defined in [/.github/workflows/ci.yml](../.github/workflows/ci.yml) and currently runs:
+
+1. Lint
+2. Unit and component tests (`npm test`)
+3. Playwright e2e (`npm run test:e2e`)
+4. Playwright visual regression (`npm run test:visual`)
+
+When a change affects runtime behavior or UI output, run the corresponding local command before opening or updating a PR.
+
+## Where Tests Live
+
+### Domain and Persistence Safety
+
+- Validation and migration: [src/domain/validation.test.ts](../src/domain/validation.test.ts)
+- Recurring date logic: [src/domain/recurring.test.ts](../src/domain/recurring.test.ts)
+- Category deletion planning: [src/domain/category-service.test.ts](../src/domain/category-service.test.ts)
+- Financial selectors/totals: [src/domain/selectors.test.ts](../src/domain/selectors.test.ts)
+- Backup export/restore: [src/backup/backup-service.test.ts](../src/backup/backup-service.test.ts), [src/backup/restore-service.test.ts](../src/backup/restore-service.test.ts)
+
+### State and Provider Behavior
+
+- Reducer transitions/invariants: [src/state/finance-reducer.test.ts](../src/state/finance-reducer.test.ts)
+- Provider hydration/persistence/theme behavior: [src/state/finance-context.test.tsx](../src/state/finance-context.test.tsx)
+- Hook usage constraints: [src/state/use-finance.test.tsx](../src/state/use-finance.test.tsx)
+
+### Feature and App Flows (RTL)
+
+- App-level user flows: [src/App.ui.test.tsx](../src/App.ui.test.tsx)
+- Transactions UI behavior: [src/features/transactions/transactions-screen.test.tsx](../src/features/transactions/transactions-screen.test.tsx)
+- Editor and settings surfaces: [src/features/transactions/transaction-editor-sheet.test.tsx](../src/features/transactions/transaction-editor-sheet.test.tsx), [src/features/recurring/recurring-editor-sheet.test.tsx](../src/features/recurring/recurring-editor-sheet.test.tsx), [src/features/settings/settings-screen.test.tsx](../src/features/settings/settings-screen.test.tsx)
+
+### Browser-Level Flows (Playwright)
+
+- Cross-screen happy paths and high-level interactions: [e2e/app.e2e.spec.ts](../e2e/app.e2e.spec.ts)
+- Visual regressions across screens/layouts/themes: [e2e/visual.spec.ts](../e2e/visual.spec.ts)
+- Deterministic browser setup utilities: [e2e/test-helpers.ts](../e2e/test-helpers.ts), [e2e/test-data.ts](../e2e/test-data.ts)
+
+## Choosing the Right Test Type
+
+### Add Unit/Integration Tests When
+
+- Changing model parsing, migration, or normalization behavior.
+- Changing reducer invariants or action semantics.
+- Changing financial computations used by Home, Insights, or Budgets.
+- Changing backup export/restore acceptance rules.
+
+These changes are usually fastest and most precisely covered in `src/**/*.test.ts` and targeted UI tests in `src/**/*.test.tsx`.
+
+### Add E2E Tests When
+
+- A user flow crosses multiple screens/components and local storage state.
+- Behavior depends on browser integration that jsdom tests do not fully represent.
+- You need confidence in navigation and interaction wiring at the app-shell level.
+
+### Add Visual Tests When
+
+- UI changes alter layout, composition, or responsive behavior.
+- Changes affect theme rendering or presentation of major screens.
+
+Visual tests are for rendered appearance regression detection, not business-rule correctness.
+
+## Risk-Sensitive Areas That Should Usually Have Targeted Tests
+
+This repo prioritizes regression prevention and data correctness. When changing these modules, add focused tests in the same PR:
+
+- [src/domain/validation.ts](../src/domain/validation.ts)
+- [src/domain/recurring.ts](../src/domain/recurring.ts)
+- [src/domain/category-service.ts](../src/domain/category-service.ts)
+- [src/domain/selectors.ts](../src/domain/selectors.ts)
+- [src/backup/restore-service.ts](../src/backup/restore-service.ts)
+- [src/persistence/finance-storage.ts](../src/persistence/finance-storage.ts)
+- [src/state/finance-reducer.ts](../src/state/finance-reducer.ts)
+- [src/state/finance-context.tsx](../src/state/finance-context.tsx)
+- [src/state/reducer-cases](../src/state/reducer-cases)
+- [src/state/reducer-utils](../src/state/reducer-utils)
+
+There is currently stronger direct test coverage for most domain/state/backup paths than for [src/persistence/indexeddb.ts](../src/persistence/indexeddb.ts), [src/pwa/register-service-worker.ts](../src/pwa/register-service-worker.ts), and [src/sw.ts](../src/sw.ts). Changes there should include focused tests where practical.
+
+## Practical PR Testing Guidance
+
+For safe, reviewable changes:
+
+1. Run `npm run test` for unit/integration coverage.
+2. Run `npm run test:e2e` when changing cross-screen behavior or orchestration.
+3. Run `npm run test:visual` for meaningful UI changes; update snapshots only for intentional visual diffs.
+4. Add narrowly scoped tests for bug-prone logic instead of broad refactors.
+
+This matches the repository review focus in [./.github/copilot-instructions.md](../.github/copilot-instructions.md): protect invariants, migration/restore safety, and financial correctness.


### PR DESCRIPTION
## Summary
This PR finalizes the documentation integration pass by connecting the new docs from README, tightening cross-links between docs, and correcting stale README wording that conflicted with the current local-first architecture.  
Impact:
- Contributors get a clearer navigation path into architecture, data model, testing, and contribution workflow docs.
- README now better matches the current codebase (no stale sync-oriented wording).

## Related issue
Closes #16 

## Type of change
- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / tech debt
- [x] Documentation
- [ ] Test-only
- [ ] Chore

## What was changed
- Added a Documentation section in README linking:
  - Architecture
  - Data model
  - Testing guide
  - Contributing guide
- Updated README terminology for consistency with current implementation:
  - Removed stale sync references
  - Aligned settings wording with current theme behavior
  - Kept local-first messaging consistent
- Improved doc navigation with small cross-links:
  - Architecture -> data model/testing/contributing
  - Testing -> contributing
- Kept changes scoped to small docs/readme consistency edits only.

## Testing
List what you ran and what was verified.

- [ ] Unit tests
- [ ] E2E tests
- [x] Manual verification

Details:
- Verified relative links across README and docs resolve.
- Reviewed headings/sections for duplicate structure and naming consistency.
- Manually reviewed final wording for concise, natural tone and alignment with current repository behavior.

## Checklist
- [x] I completed a self-review of this PR.
- [x] I added or updated tests where needed.
- [x] I updated documentation when behavior or developer workflow changed.
- [x] This PR does not include unrelated changes.