### PR TITLE
Improve update metadata/changelog UX and fix transaction date presentation regressions

### DIFF
--- a/.changeset/short-birds-hunt.md
+++ b/.changeset/short-birds-hunt.md
@@ -2,4 +2,4 @@
 "tally": minor
 ---
 
-[severity:minor] Fixes Home Recent transactions to exclude future-dated entries while keeping today and past items sorted newest-first. Also fixes update metadata generation to read changelog and severity from changeset fragments instead of falling back to the default changelog when metadata is available.
+[severity:minor] Fixes Home Recent transactions to exclude future-dated entries while keeping today and past items sorted newest-first, and makes the related tests timezone-safe. Improves update metadata parsing so changelog/severity are derived correctly from changesets (including case-insensitive severity markers), with fallback text only when changelog entries are unavailable. Enhances the update dialog changelog UX with Show more/Show less for long entries, and centers Records date chips so they no longer obscure leading transaction text.

--- a/src/features/backup/update-manager.test.tsx
+++ b/src/features/backup/update-manager.test.tsx
@@ -77,6 +77,23 @@ describe('UpdateManager', () => {
     expect(hookState.value.applyUpdate).toHaveBeenCalled()
   })
 
+  it('collapses long changelog entries and expands on demand', async () => {
+    const { user } = renderWithUser(
+      <UpdateManager onCreateBackup={vi.fn(async () => true)} />,
+    )
+
+    expect(screen.getByText('Improved charts')).toBeInTheDocument()
+    expect(screen.getByText('Safer backups')).toBeInTheDocument()
+    expect(screen.getByText('Update prompt')).toBeInTheDocument()
+    expect(screen.queryByText('Ignored')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show more' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Show more' }))
+
+    expect(screen.getByText('Ignored')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show less' })).toBeInTheDocument()
+  })
+
   it('does not render when no update is available', () => {
     hookState.value = {
       ...hookState.value,

--- a/src/features/backup/update-manager.tsx
+++ b/src/features/backup/update-manager.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useServiceWorkerUpdate } from '../../pwa/use-service-worker-update'
 import {
+  MAX_CHANGELOG_ITEMS,
   getUpdateDisplayInfo,
   getUpdateSeverityDecision,
 } from '../../pwa/update-prompt-state'
@@ -25,6 +26,7 @@ export function UpdateManager({ onCreateBackup }: UpdateManagerProps) {
   const [hasCompletedRequiredBackup, setHasCompletedRequiredBackup] =
     useState(false)
   const [isBackingUp, setIsBackingUp] = useState(false)
+  const [isChangelogExpanded, setIsChangelogExpanded] = useState(false)
 
   const versionKey = availableVersionInfo?.version ?? 'no-update'
 
@@ -32,11 +34,29 @@ export function UpdateManager({ onCreateBackup }: UpdateManagerProps) {
     setStep('prompt')
     setHasCompletedRequiredBackup(false)
     setIsBackingUp(false)
+    setIsChangelogExpanded(false)
   }, [versionKey])
 
-  const changelog = useMemo(
-    () => getUpdateDisplayInfo(availableVersionInfo).changelog,
-    [availableVersionInfo],
+  const changelog = useMemo(() => {
+    if (!Array.isArray(availableVersionInfo?.changelog)) {
+      return []
+    }
+
+    return availableVersionInfo.changelog
+      .filter((entry): entry is string => typeof entry === 'string')
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0)
+  }, [availableVersionInfo])
+  const visibleChangelog = useMemo(
+    () =>
+      isChangelogExpanded
+        ? changelog
+        : changelog.slice(0, MAX_CHANGELOG_ITEMS),
+    [changelog, isChangelogExpanded],
+  )
+  const canExpandChangelog = useMemo(
+    () => changelog.length > MAX_CHANGELOG_ITEMS,
+    [changelog],
   )
 
   if (!promptVisible || !availableVersionInfo) {
@@ -177,11 +197,32 @@ export function UpdateManager({ onCreateBackup }: UpdateManagerProps) {
             <p className="support-copy">Version {displayInfo.version}</p>
           ) : null}
           {changelog.length > 0 ? (
-            <ul className="update-changelog-list">
-              {changelog.map((entry) => (
-                <li key={entry}>{entry}</li>
-              ))}
-            </ul>
+            <div className="update-changelog-block">
+              <div
+                id="update-changelog-region"
+                className="update-changelog-scroll"
+                data-expanded={isChangelogExpanded}
+              >
+                <ul className="update-changelog-list">
+                  {visibleChangelog.map((entry) => (
+                    <li key={entry}>{entry}</li>
+                  ))}
+                </ul>
+              </div>
+              {canExpandChangelog ? (
+                <button
+                  type="button"
+                  className="text-button update-changelog-toggle"
+                  aria-controls="update-changelog-region"
+                  aria-expanded={isChangelogExpanded}
+                  onClick={() => {
+                    setIsChangelogExpanded((current) => !current)
+                  }}
+                >
+                  {isChangelogExpanded ? 'Show less' : 'Show more'}
+                </button>
+              ) : null}
+            </div>
           ) : null}
           {severityDecision.requiresWarningStep && !needsReload ? (
             <p className="support-copy">

--- a/src/index.css
+++ b/src/index.css
@@ -473,13 +473,34 @@ textarea:focus-visible {
 .update-changelog-list {
   display: grid;
   gap: 8px;
-  margin: 4px 0 0;
+  margin: 0;
   padding-left: 18px;
   color: var(--text-secondary);
 }
 
 .update-changelog-list li {
   line-height: 1.4;
+}
+
+.update-changelog-block {
+  display: grid;
+  gap: 8px;
+}
+
+.update-changelog-scroll {
+  overflow: hidden;
+}
+
+.update-changelog-scroll[data-expanded='true'] {
+  max-height: 180px;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.update-changelog-toggle {
+  justify-self: flex-start;
+  font-size: 0.86rem;
+  padding: 0;
 }
 
 .backup-modal-actions {
@@ -1226,6 +1247,8 @@ textarea:focus-visible {
   position: sticky;
   top: 62px;
   z-index: 2;
+  justify-self: center;
+  margin-inline: auto;
   padding: 8px 12px;
   border-radius: 999px;
   width: fit-content;

--- a/src/index.css
+++ b/src/index.css
@@ -500,7 +500,8 @@ textarea:focus-visible {
 .update-changelog-toggle {
   justify-self: flex-start;
   font-size: 0.86rem;
-  padding: 0;
+  padding-block: 4px;
+  padding-inline: 0;
 }
 
 .backup-modal-actions {


### PR DESCRIPTION
## Summary
This PR resolves multiple UX and correctness issues around updates and transaction history:
- Prevents future-dated items from appearing in Home Recent Transactions and keeps sorting behavior intact.
- Improves update metadata parsing from changesets so severity/changelog are derived reliably (including case-insensitive severity markers) with safe fallback behavior.
- Improves the update prompt changelog display for longer release notes with expand/collapse controls.
- Repositions sticky date chips in Records to the center so they no longer obscure leading transaction text.

## Related issue
Closes #42 

## Type of change
- [x] Bug fix
- [x] Feature
- [ ] Refactor / tech debt
- [ ] Documentation
- [x] Test-only
- [ ] Chore

## What was changed
- Updated Recent Transactions selection logic and tests for future-date exclusion and timezone-stable time mocking in selectors.ts and selectors.test.ts.
- Updated update metadata/severity parsing behavior in vite.config.ts.
- Added update dialog changelog expand/collapse UI and tests in update-manager.tsx and update-manager.test.tsx.
- Centered sticky date chips in Records list in index.css.
- Refreshed release note fragment in short-birds-hunt.md.

## Testing
List what you ran and what was verified.

- [x] Unit tests
- [ ] E2E tests
- [ ] Manual verification

Details:
- Ran: npm run test -- selectors.test.ts update-manager.test.tsx
- Verified:
  - Recent Transactions excludes future dates and includes today/past correctly.
  - UpdateManager changelog expand/collapse behavior works and existing update flows still pass.

## Checklist
- [x] I completed a self-review of this PR.
- [x] I added or updated tests where needed.
- [ ] I updated documentation when behavior or developer workflow changed.
- [x] This PR does not include unrelated changes.