### PR TITLE
Fix update prompt changelog overflow and keep actions reachable on small screens

### DIFF
--- a/.changeset/calm-bugs-wave.md
+++ b/.changeset/calm-bugs-wave.md
@@ -2,4 +2,4 @@
 "tally": patch
 ---
 
-[severity:minor] Adds a Help and Feedback section in Settings with GitHub bug reporting, app info copy, and supporting visual and browser-flow coverage.
+[severity:minor] Fixes the update prompt changelog layout so release notes always render inside a bordered, rounded, scrollable container, preventing long content from pushing action buttons off-screen on small mobile/PWA viewports.

--- a/.changeset/calm-bugs-wave.md
+++ b/.changeset/calm-bugs-wave.md
@@ -2,4 +2,4 @@
 "tally": patch
 ---
 
-[severity:minor] Fixes the update prompt changelog layout so release notes always render inside a bordered, rounded, scrollable container, preventing long content from pushing action buttons off-screen on small mobile/PWA viewports.
+[severity:minor] Adds a Help and Feedback section in Settings with GitHub bug reporting, app info copy, and supporting visual and browser-flow coverage.

--- a/.changeset/fast-towers-nod.md
+++ b/.changeset/fast-towers-nod.md
@@ -1,0 +1,5 @@
+---
+"tally": patch
+---
+
+[severity:minor] Fixes the update prompt changelog layout so release notes always render inside a bordered, rounded, scrollable container, preventing long content from pushing action buttons off-screen on small mobile/PWA viewports.

--- a/e2e/app-update.e2e.spec.ts
+++ b/e2e/app-update.e2e.spec.ts
@@ -131,3 +131,57 @@ test('recommended-backup updates warn first but can proceed without backup', asy
     return state?.workerMessages?.length ?? 0
   }).toBe(1)
 })
+
+test('long changelog stays scrollable and keeps update actions visible on mobile', async ({ page }) => {
+  await freezeTime(page)
+  await seedAppState(page, createSeedState({ withTransactions: false }))
+  await page.setViewportSize({ width: 390, height: 844 })
+
+  await page.goto('/')
+  await waitForAppReady(page)
+  await resetUpdateTestHooks(page)
+
+  const longChangelog = Array.from({ length: 40 }, (_, index) => `Changelog item ${index + 1}`)
+
+  await simulateUpdateAvailable(page, {
+    availableVersionInfo: {
+      version: '1.6.0',
+      changelog: longChangelog,
+      severity: 'minor',
+    },
+    withMockWaitingWorker: true,
+  })
+
+  const dialog = page.getByRole('dialog', { name: 'Update available' })
+  await expect(dialog).toBeVisible()
+
+  const changelogRegion = page.locator('#update-changelog-region')
+  await expect(changelogRegion).toBeVisible()
+
+  const hasInternalScroll = await changelogRegion.evaluate((node) => {
+    return node.scrollHeight > node.clientHeight
+  })
+  expect(hasInternalScroll).toBe(true)
+
+  const updateButton = page.getByRole('button', { name: 'Update' })
+  const laterButton = page.getByRole('button', { name: 'Later' })
+
+  await expect(updateButton).toBeVisible()
+  await expect(laterButton).toBeVisible()
+
+  const viewportHeight = page.viewportSize()?.height ?? 0
+  const updateBox = await updateButton.boundingBox()
+  const laterBox = await laterButton.boundingBox()
+
+  expect(updateBox).not.toBeNull()
+  expect(laterBox).not.toBeNull()
+  expect((updateBox?.y ?? 0) + (updateBox?.height ?? 0)).toBeLessThanOrEqual(viewportHeight)
+  expect((laterBox?.y ?? 0) + (laterBox?.height ?? 0)).toBeLessThanOrEqual(viewportHeight)
+
+  await updateButton.click()
+
+  await expect.poll(async () => {
+    const state = await getUpdateTestState(page)
+    return state?.workerMessages?.length ?? 0
+  }).toBe(1)
+})

--- a/e2e/app-update.e2e.spec.ts
+++ b/e2e/app-update.e2e.spec.ts
@@ -168,15 +168,8 @@ test('long changelog stays scrollable and keeps update actions visible on mobile
 
   await expect(updateButton).toBeVisible()
   await expect(laterButton).toBeVisible()
-
-  const viewportHeight = page.viewportSize()?.height ?? 0
-  const updateBox = await updateButton.boundingBox()
-  const laterBox = await laterButton.boundingBox()
-
-  expect(updateBox).not.toBeNull()
-  expect(laterBox).not.toBeNull()
-  expect((updateBox?.y ?? 0) + (updateBox?.height ?? 0)).toBeLessThanOrEqual(viewportHeight)
-  expect((laterBox?.y ?? 0) + (laterBox?.height ?? 0)).toBeLessThanOrEqual(viewportHeight)
+  await expect(updateButton).toBeInViewport()
+  await expect(laterButton).toBeInViewport()
 
   await updateButton.click()
 

--- a/src/features/backup/update-manager.test.tsx
+++ b/src/features/backup/update-manager.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { screen } from '@testing-library/react'
+import { screen, within } from '@testing-library/react'
 import { UpdateManager } from './update-manager'
 import { renderWithUser } from '../../test/render-utils'
 import type { AppVersionInfo } from '../../pwa/app-version'
@@ -77,15 +77,20 @@ describe('UpdateManager', () => {
     expect(hookState.value.applyUpdate).toHaveBeenCalled()
   })
 
-  it('shows all changelog entries in the changelog container', () => {
+  it('shows all changelog entries inside the dedicated changelog scroll region', () => {
     renderWithUser(
       <UpdateManager onCreateBackup={vi.fn(async () => true)} />,
     )
 
-    expect(screen.getByText('Improved charts')).toBeInTheDocument()
-    expect(screen.getByText('Safer backups')).toBeInTheDocument()
-    expect(screen.getByText('Update prompt')).toBeInTheDocument()
-    expect(screen.getByText('Ignored')).toBeInTheDocument()
+    const changelogRegion = document.getElementById('update-changelog-region')
+    expect(changelogRegion).toBeInTheDocument()
+    expect(changelogRegion).toHaveClass('update-changelog-scroll')
+
+    const changelogList = within(changelogRegion as HTMLElement).getByRole('list')
+    expect(within(changelogList).getByText('Improved charts')).toBeInTheDocument()
+    expect(within(changelogList).getByText('Safer backups')).toBeInTheDocument()
+    expect(within(changelogList).getByText('Update prompt')).toBeInTheDocument()
+    expect(within(changelogList).getByText('Ignored')).toBeInTheDocument()
   })
 
   it('does not render when no update is available', () => {

--- a/src/features/backup/update-manager.test.tsx
+++ b/src/features/backup/update-manager.test.tsx
@@ -77,7 +77,7 @@ describe('UpdateManager', () => {
     expect(hookState.value.applyUpdate).toHaveBeenCalled()
   })
 
-  it('shows all changelog entries in an always-scrollable container', () => {
+  it('shows all changelog entries in the changelog container', () => {
     renderWithUser(
       <UpdateManager onCreateBackup={vi.fn(async () => true)} />,
     )
@@ -86,8 +86,6 @@ describe('UpdateManager', () => {
     expect(screen.getByText('Safer backups')).toBeInTheDocument()
     expect(screen.getByText('Update prompt')).toBeInTheDocument()
     expect(screen.getByText('Ignored')).toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Show more' })).not.toBeInTheDocument()
-    expect(screen.queryByRole('button', { name: 'Show less' })).not.toBeInTheDocument()
   })
 
   it('does not render when no update is available', () => {

--- a/src/index.css
+++ b/src/index.css
@@ -428,11 +428,14 @@ textarea:focus-visible {
 .update-modal-panel {
   gap: 16px;
   max-height: calc(100svh - 36px);
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
   overflow: hidden;
 }
 
 .update-modal-panel .backup-modal-copy {
   min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .report-bug-modal-panel {

--- a/src/index.css
+++ b/src/index.css
@@ -427,6 +427,12 @@ textarea:focus-visible {
 
 .update-modal-panel {
   gap: 16px;
+  max-height: calc(100svh - 36px);
+  overflow: hidden;
+}
+
+.update-modal-panel .backup-modal-copy {
+  min-height: 0;
 }
 
 .report-bug-modal-panel {
@@ -489,9 +495,13 @@ textarea:focus-visible {
 }
 
 .update-changelog-scroll {
-  max-height: 180px;
+  max-height: min(220px, 30svh);
   overflow-y: auto;
-  padding-right: 6px;
+  overscroll-behavior: contain;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.02);
+  padding: 10px 12px;
 }
 
 .backup-modal-actions {


### PR DESCRIPTION
## Summary
Fixes issue #51 in the update manager dialog where long changelog text could expand the prompt and push action buttons below the viewport. The changelog is now consistently presented inside a dedicated bordered, rounded, scrollable area so the modal remains usable on mobile and PWA-sized screens.

## Related issue
Closes #51

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / tech debt
- [ ] Documentation
- [ ] Test-only
- [ ] Chore

## What was changed
- Removed obsolete show more/show less assumptions from update manager tests.
- Kept changelog rendering in a dedicated scroll area and updated styles to:
- use an accent-themed visible border
- add rounded corners
- cap changelog height and keep scrolling inside the changelog area
- cap update modal height to viewport and prevent layout growth that hides actions
- Preserved update flow behavior and action semantics (Later, Update/Reload, backup-required flows).

## Testing
List what you ran and what was verified.

- [x] Unit tests
- [ ] E2E tests
- [x] Manual verification

Details:
- Ran focused unit tests for update manager:
- update-manager.test.tsx
- update-manager.integration.test.tsx
- Confirmed tests pass and update actions remain reachable under long changelog scenarios due to modal/changelog layout constraints.

## Checklist
- [x] I completed a self-review of this PR.
- [x] I added or updated tests where needed.
- [ ] I updated documentation when behavior or developer workflow changed.
- [x] This PR does not include unrelated changes.