### PR TITLE
Fix recurring editor sheet getting stuck by adding close control and reliable post-save/stop dismissal

### DIFF
--- a/.changeset/green-rings-jump.md
+++ b/.changeset/green-rings-jump.md
@@ -1,0 +1,5 @@
+---
+"tally": patch
+---
+
+[severity:minor] Fixes the recurring editor sheet in Settings so it always has a visible close button and reliably dismisses after successful Save recurring or Stop recurring actions.

--- a/src/features/recurring/recurring-editor-sheet.test.tsx
+++ b/src/features/recurring/recurring-editor-sheet.test.tsx
@@ -1,8 +1,31 @@
 import { describe, expect, it, vi } from 'vitest'
-import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
 import { RecurringEditorSheet } from './recurring-editor-sheet'
 import { createFinanceContextValue, renderWithFinance } from '../../test/finance-test-utils'
 import { initialFinanceState } from '../../domain/default-data'
+import { FinanceContext } from '../../state/finance-store'
+import type { RecurringTemplate } from '../../domain/models'
+
+function createRecurringTemplate(
+  overrides: Partial<RecurringTemplate> = {},
+): RecurringTemplate {
+  return {
+    id: overrides.id ?? 'rec-1',
+    type: overrides.type ?? 'expense',
+    amount: overrides.amount ?? 25,
+    categoryId: overrides.categoryId ?? 'cat-food',
+    note: overrides.note ?? 'Meal plan',
+    frequency: overrides.frequency ?? 'monthly',
+    intervalDays: overrides.intervalDays ?? null,
+    startDate: overrides.startDate ?? '2026-03-01',
+    nextDueDate: overrides.nextDueDate ?? '2026-04-01',
+    active: overrides.active ?? true,
+    createdAt: overrides.createdAt ?? '2026-03-01T08:00:00.000Z',
+    updatedAt: overrides.updatedAt ?? '2026-03-01T08:00:00.000Z',
+  }
+}
 
 function createContextValue() {
   const updateRecurringTemplate = vi.fn()
@@ -15,20 +38,7 @@ function createContextValue() {
       ...initialFinanceState,
       categories: [...initialFinanceState.categories],
       recurringTemplates: [
-        {
-          id: 'rec-1',
-          type: 'expense',
-          amount: 25,
-          categoryId: 'cat-food',
-          note: 'Meal plan',
-          frequency: 'monthly',
-          intervalDays: null,
-          startDate: '2026-03-01',
-          nextDueDate: '2026-04-01',
-          active: true,
-          createdAt: '2026-03-01T08:00:00.000Z',
-          updatedAt: '2026-03-01T08:00:00.000Z',
-        },
+        createRecurringTemplate(),
       ],
     },
     updateRecurringTemplate,
@@ -44,16 +54,115 @@ function createContextValue() {
   }
 }
 
+function renderStatefulSheet() {
+  const updateRecurringTemplateSpy = vi.fn()
+  const stopRecurringTemplateSpy = vi.fn()
+  const onClose = vi.fn()
+  const onShowToast = vi.fn()
+
+  function Harness() {
+    const [state, setState] = useState({
+      ...initialFinanceState,
+      categories: [...initialFinanceState.categories],
+      recurringTemplates: [createRecurringTemplate()],
+    })
+    const [isOpen, setIsOpen] = useState(true)
+
+    const updateRecurringTemplate = (
+      input: Parameters<typeof updateRecurringTemplateSpy>[0],
+    ) => {
+      updateRecurringTemplateSpy(input)
+      setState((current) => ({
+        ...current,
+        recurringTemplates: current.recurringTemplates.map((template) =>
+          template.id === input.id
+            ? {
+                ...template,
+                ...input,
+                amount: Math.abs(input.amount),
+                note: input.note.trim(),
+                intervalDays:
+                  input.frequency === 'custom'
+                    ? Math.floor(input.intervalDays ?? 1)
+                    : null,
+                active: true,
+                updatedAt: '2026-04-01T09:00:00.000Z',
+              }
+            : template,
+        ),
+      }))
+    }
+
+    const stopRecurringTemplate = (templateId: string) => {
+      stopRecurringTemplateSpy(templateId)
+      setState((current) => ({
+        ...current,
+        recurringTemplates: current.recurringTemplates.map((template) =>
+          template.id === templateId
+            ? {
+                ...template,
+                active: false,
+                updatedAt: '2026-04-01T09:10:00.000Z',
+              }
+            : template,
+        ),
+      }))
+    }
+
+    const contextValue = createFinanceContextValue({
+      state,
+      updateRecurringTemplate,
+      stopRecurringTemplate,
+    })
+
+    return (
+      <FinanceContext.Provider value={contextValue}>
+        {isOpen ? (
+          <RecurringEditorSheet
+            templateId="rec-1"
+            onClose={() => {
+              onClose()
+              setIsOpen(false)
+            }}
+            onShowToast={onShowToast}
+          />
+        ) : null}
+      </FinanceContext.Provider>
+    )
+  }
+
+  return {
+    user: userEvent.setup(),
+    ...render(<Harness />),
+    updateRecurringTemplateSpy,
+    stopRecurringTemplateSpy,
+    onClose,
+    onShowToast,
+  }
+}
+
 describe('RecurringEditorSheet', () => {
+  it('renders a close button and dismisses when it is clicked', async () => {
+    const { user, onClose } = renderStatefulSheet()
+
+    const dialog = await screen.findByRole('dialog', {
+      name: 'Edit future recurring transactions',
+    })
+
+    await user.click(within(dialog).getByRole('button', { name: 'Close recurring editor' }))
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled()
+      expect(
+        screen.queryByRole('dialog', { name: 'Edit future recurring transactions' }),
+      ).not.toBeInTheDocument()
+    })
+  })
+
   it('validates custom interval and saves updates', async () => {
-    const { contextValue, updateRecurringTemplate, onClose, onShowToast } =
-      createContextValue()
+    const { contextValue, updateRecurringTemplate, onClose, onShowToast } = createContextValue()
     const { user } = renderWithFinance(
-      <RecurringEditorSheet
-        templateId="rec-1"
-        onClose={onClose}
-        onShowToast={onShowToast}
-      />,
+      <RecurringEditorSheet templateId="rec-1" onClose={onClose} onShowToast={onShowToast} />,
       contextValue,
     )
 
@@ -93,27 +202,59 @@ describe('RecurringEditorSheet', () => {
     })
   }, 10000)
 
-  it('stops recurring after confirmation', async () => {
-    const { contextValue, stopRecurringTemplate, onClose, onShowToast } =
-      createContextValue()
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
-    const { user } = renderWithFinance(
-      <RecurringEditorSheet
-        templateId="rec-1"
-        onClose={onClose}
-        onShowToast={onShowToast}
-      />,
-      contextValue,
-    )
+  it('dismisses after successful recurring save', async () => {
+    const {
+      user,
+      updateRecurringTemplateSpy,
+      onClose,
+      onShowToast,
+    } = renderStatefulSheet()
 
-    await screen.findByRole('dialog', { name: 'Edit future recurring transactions' })
-    await user.click(screen.getByRole('button', { name: 'Stop recurring' }))
+    const dialog = await screen.findByRole('dialog', {
+      name: 'Edit future recurring transactions',
+    })
+
+    await user.clear(screen.getByRole('spinbutton', { name: 'Recurring amount' }))
+    await user.type(screen.getByRole('spinbutton', { name: 'Recurring amount' }), '30')
+    await user.click(within(dialog).getByRole('button', { name: 'Save recurring' }))
+
+    await waitFor(() => {
+      expect(updateRecurringTemplateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'rec-1',
+          amount: 30,
+        }),
+      )
+      expect(onShowToast).toHaveBeenCalledWith('Recurring updated.')
+      expect(onClose).toHaveBeenCalled()
+      expect(
+        screen.queryByRole('dialog', { name: 'Edit future recurring transactions' }),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it('dismisses after successful recurring stop', async () => {
+    const {
+      user,
+      stopRecurringTemplateSpy,
+      onClose,
+      onShowToast,
+    } = renderStatefulSheet()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+
+    const dialog = await screen.findByRole('dialog', {
+      name: 'Edit future recurring transactions',
+    })
+    await user.click(within(dialog).getByRole('button', { name: 'Stop recurring' }))
 
     expect(confirmSpy).toHaveBeenCalled()
     await waitFor(() => {
-      expect(stopRecurringTemplate).toHaveBeenCalledWith('rec-1')
+      expect(stopRecurringTemplateSpy).toHaveBeenCalledWith('rec-1')
       expect(onShowToast).toHaveBeenCalledWith('Recurring stopped.')
       expect(onClose).toHaveBeenCalled()
+      expect(
+        screen.queryByRole('dialog', { name: 'Edit future recurring transactions' }),
+      ).not.toBeInTheDocument()
     })
 
     confirmSpy.mockRestore()

--- a/src/features/recurring/recurring-editor-sheet.tsx
+++ b/src/features/recurring/recurring-editor-sheet.tsx
@@ -48,11 +48,6 @@ export function RecurringEditorSheet({
   const closeTimeoutRef = useRef<number | null>(null)
 
   useEffect(() => {
-    if (!template) {
-      onClose()
-      return
-    }
-
     const frame = window.requestAnimationFrame(() => {
       setSheetState('open')
     })
@@ -63,6 +58,12 @@ export function RecurringEditorSheet({
       if (closeTimeoutRef.current !== null) {
         window.clearTimeout(closeTimeoutRef.current)
       }
+    }
+  }, [templateId])
+
+  useEffect(() => {
+    if (!template) {
+      onClose()
     }
   }, [onClose, template])
 
@@ -153,8 +154,9 @@ export function RecurringEditorSheet({
       return
     }
 
+    stopRecurringTemplate(template.id)
+
     requestClose(() => {
-      stopRecurringTemplate(template.id)
       onShowToast('Recurring stopped.')
     })
   }
@@ -181,6 +183,16 @@ export function RecurringEditorSheet({
             <p className="eyebrow">Recurring</p>
             <h3 id="recurring-sheet-title">Edit future recurring transactions</h3>
           </div>
+
+          <button
+            type="button"
+            className="icon-button sheet-close-button"
+            aria-label="Close recurring editor"
+            title="Close"
+            onClick={() => requestClose()}
+          >
+            <span aria-hidden="true">&#215;</span>
+          </button>
         </div>
 
         <form className="field-grid transaction-sheet-form" onSubmit={handleSubmit}>


### PR DESCRIPTION
Fixes a critical UX bug in recurring transaction management where the “Edit future recurring transactions” sheet could become impossible to exit. This PR adds an explicit close control and ensures the sheet dismisses reliably after successful Save recurring and Stop recurring actions, while preserving existing recurring data behavior.

## Related issue
Closes #53

## Type of change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / tech debt
- [ ] Documentation
- [ ] Test-only
- [ ] Chore

## What was changed
- Added a visible header close button to the recurring editor sheet, aligned with existing sheet/dialog patterns.
- Wired the new close button to the existing sheet close flow.
- Fixed recurring editor close lifecycle timing so state updates during save/stop no longer cancel dismissal.
- Ensured successful Save recurring dismisses the sheet after update.
- Ensured successful Stop recurring dismisses the sheet after stop action.
- Kept backdrop dismissal behavior unchanged for consistency.
- Extended recurring editor tests to cover:
  - close button rendering
  - close button dismissal
  - dismissal after successful save
  - dismissal after successful stop

## Testing
List what you ran and what was verified.

- [x] Unit tests
- [ ] E2E tests
- [x] Manual verification

Details:
- Ran: `npm test -- src/features/recurring/recurring-editor-sheet.test.tsx`
- Verified:
  - recurring editor renders with close button
  - clicking close button dismisses dialog
  - successful save dismisses dialog
  - successful stop dismisses dialog
  - existing validation/save behavior remains covered by tests

## Checklist
- [x] I completed a self-review of this PR.
- [x] I added or updated tests where needed.
- [ ] I updated documentation when behavior or developer workflow changed.
- 